### PR TITLE
Fix txn errors caused by self.txnQueries being undefined

### DIFF
--- a/ch2driver/pytpcc/drivers/nestcollectionsdriver.py
+++ b/ch2driver/pytpcc/drivers/nestcollectionsdriver.py
@@ -789,10 +789,10 @@ class NestcollectionsDriver(AbstractDriver):
 
         if TAFlag == "T":
             if self.schema == constants.CH2_DRIVER_SCHEMA["CH2"]:
-                self.txnQueries = TXN_QUERIES
+                txnQueries = TXN_QUERIES
             else:
-                self.txnQueries = CH2PP_TXN_QUERIES
-            for txn, queries in self.txnQueries.items():
+                txnQueries = CH2PP_TXN_QUERIES
+            for txn, queries in txnQueries.items():
                 for query, statement in queries.items():
                     if query == "getStockInfo":
                         for i in range(1,11):
@@ -1074,7 +1074,6 @@ class NestcollectionsDriver(AbstractDriver):
 
         # print ("Entering doDelivery")
         txn = "DELIVERY"
-        q = self.txnQueries[txn]
         w_id = params["w_id"]
         o_carrier_id = params["o_carrier_id"]
         ol_delivery_d = params["ol_delivery_d"]
@@ -1139,7 +1138,6 @@ class NestcollectionsDriver(AbstractDriver):
 
         # print "Entering doNewOrder"
         txn = "NEW_ORDER"
-        q = self.txnQueries[txn]
         d_next_o_id = 0
         w_id = params["w_id"]
         d_id = params["d_id"]
@@ -1321,7 +1319,6 @@ class NestcollectionsDriver(AbstractDriver):
 
 #       print ("Entering doOrderStatus")
         txn = "ORDER_STATUS"
-        q = self.txnQueries[txn]
         w_id = params["w_id"]
         d_id = params["d_id"]
         c_id = params["c_id"]
@@ -1379,7 +1376,6 @@ class NestcollectionsDriver(AbstractDriver):
         randomhost = self.query_node
 
         txn = "PAYMENT"
-        q = self.txnQueries[txn]
         w_id = params["w_id"]
         d_id = params["d_id"]
         h_amount = params["h_amount"]
@@ -1501,8 +1497,6 @@ class NestcollectionsDriver(AbstractDriver):
 
         # print "Entering doStockLevel"
         txn = "STOCK_LEVEL"
-        q = self.txnQueries[txn]
-
         w_id = params["w_id"]
         d_id = params["d_id"]
         threshold = params["threshold"]


### PR DESCRIPTION
As described by @bochun in https://jira.issues.couchbase.com/browse/CBPS-1464, we were seeing 0 TPM in our perf tests, which was because transactions were all failing with the following error:
```
'NestcollectionsDriver' object has no attribute 'txnQueries'
```

This PR fixes those errors by removing the triggering (and otherwise redundant) lines of code.

It is a bit subtle because `self.txnQueries` does get defined in the `NestcollectionsDriver` constructor, but only conditionally. When the driver is used via `startExecution` in `tpcc.py`, `self.txnQueries` doesn't get defined because the constructor returns _beforehand_ here:
```
if clientId >= 0:
    self.prepared_dict = prepared_dict
    return
```